### PR TITLE
submit method had the wrong return type

### DIFF
--- a/src/CreditCard.tsx
+++ b/src/CreditCard.tsx
@@ -79,7 +79,7 @@ const Images: any = {
 };
 
 export type CreditCardType = {
-  submit: () => void;
+  submit: () => {error: Error | null, data: CardData};
 };
 
 interface CardData {


### PR DESCRIPTION
This method used to simply return `void`, which made it impossible to safely destruct the method's response into its returned components in typescript