### PR TITLE
feat: add read only prop for input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const styles = StyleSheet.create({
 |**`placeholderTextColor`**| Placeholder color (normal state) | `string`  | #9B84A9 |
 |**`errorTextColor`**| Placeholder color (error state) | `string` | #F15A5B |
 |**`onValidStateChange`**| Called when card valid state changes (`true` or `false`) | `func` |(validCard) => null|
+|**`readOnly`**| Makes card inputs not editable (optional, and each field is optional) | *object* | { number: false, holder: false, expiration: false, cvv: false } |
 
 ### Methods (Imperative API):
 

--- a/src/CreditCard.tsx
+++ b/src/CreditCard.tsx
@@ -63,7 +63,7 @@ const validationSchema = yup.object().shape({
     .defined()
     .test('is-valid-cvv', 'Card CVV is invalid', function (cvv: any) {
       const { runtime = false } = this.options.context as any;
-      const { isPotentiallyValid, isValid } = cardValidator.cvv(cvv);
+      const { isPotentiallyValid, isValid } = cardValidator.cvv(cvv, [3, 4]);
       return runtime ? isPotentiallyValid : isValid;
     }),
 });
@@ -263,6 +263,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
         const numberMask = maskChars.join('');
 
         const cvvMask = ''.padStart(code.size, '9');
+        console.log(type);
         const brandImage = Images.brands[type]
           ? Images.brands[type]
           : Images.brands.default;

--- a/src/CreditCard.tsx
+++ b/src/CreditCard.tsx
@@ -27,6 +27,7 @@ const validationSchema = yup.object().shape({
   holder: yup
     .string()
     .defined()
+    .max(24)
     .test('is-valid-holder', 'Holder name is invalid', function (
       holderName: any
     ) {
@@ -438,6 +439,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
                     styles.textData,
                     { color: errors.holder ? errorTextColor : textColor },
                   ]}
+                  maxLength={24}
                   value={cardData?.holder}
                   refInput={holderInputRef}
                   onSubmitEditing={() => focusField(expirationInputRef)}

--- a/src/CreditCard.tsx
+++ b/src/CreditCard.tsx
@@ -103,6 +103,12 @@ interface CreditCardProps {
     expiration?: string;
     cvv?: string;
   };
+  readOnly?: {
+    number?: boolean;
+    holder?: boolean;
+    expiration?: boolean;
+    cvv?: boolean;
+  };
   expirationDateFormat?: 'MM/YYYY' | 'MM/YY';
   initialValues?: CardData;
   background?: string | any;
@@ -136,6 +142,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
       initialValues,
       expirationDateFormat,
       onValidStateChange,
+      readOnly,
     }: any,
     ref
   ) => {
@@ -387,6 +394,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
                 placeholderTextColor={placeholderTextColor}
                 name="number"
                 onChange={handleInputChange}
+                editable={!readOnly?.number}
                 value={cardData?.number}
                 autoFocus
                 placeholder={placeholders.number}
@@ -422,6 +430,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
                   textContentType="name"
                   returnKeyType="next"
                   onChange={handleInputChange}
+                  editable={!readOnly?.holder}
                   placeholder={placeholders.holder}
                   autoCapitalize="characters"
                   style={[
@@ -445,6 +454,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
                   keyboardType="numbers-and-punctuation"
                   returnKeyType="next"
                   onChange={handleInputChange}
+                  editable={!readOnly?.expiration}
                   placeholder={placeholders.expiration}
                   style={[
                     styles.textData,
@@ -491,6 +501,7 @@ const CreditCard = React.forwardRef<CreditCardType, CreditCardProps>(
                 returnKeyType="done"
                 onChange={handleInputChange}
                 placeholder={placeholders.cvv}
+                editable={!readOnly?.cvv}
                 style={[
                   styles.textData,
                   { color: errors.cvv ? errorTextColor : textColor },


### PR DESCRIPTION
#6 

I would like to edit the card, but only if the CVV or Exp Changes. This allows for making the input fields not editable